### PR TITLE
Logic analyzer updates

### DIFF
--- a/Redstone Logic Analyzer Tool/Redstone Logic Analyzer.py
+++ b/Redstone Logic Analyzer Tool/Redstone Logic Analyzer.py
@@ -30,9 +30,13 @@ class RedstoneLogicAnalyzer:
 		print("Failed Channels:")
 		for failure in self.renderer.report_failed_signals():
 			print(failure)
+
+
+if __name__ == "__main__":
+	# execute only if run as a script
 	
-try:		
-	RedstoneLogicAnalyzer().main()
-except Exception as e:
-	print("Encountered Exception: {}".format(e))
-input("Press Enter to Continue...")
+	try:
+		RedstoneLogicAnalyzer().main()
+	except Exception as e:
+		print("Encountered Exception: {}".format(e))
+	input("Press Enter to Continue...")

--- a/Redstone Logic Analyzer Tool/Redstone Logic Analyzer.py
+++ b/Redstone Logic Analyzer Tool/Redstone Logic Analyzer.py
@@ -1,5 +1,6 @@
 from logic_analyzer.screen_renderer import ScreenRenderer
 from argparse import ArgumentParser
+import os
 
 
 class RedstoneLogicAnalyzer:
@@ -20,8 +21,18 @@ class RedstoneLogicAnalyzer:
 
 		If log_address or channels_to_render is None then the user will be prompted for it.
 		"""
-		if self.log_address is None:
-			self.log_address 		= input("Where's latest.log? > ")
+		if self.log_address:
+			# If log_address is None then we are still waiting for user input, no need to check validity.
+			log_address_valid = os.path.isfile(self.log_address)
+		else:
+			log_address_valid = False
+
+		while not log_address_valid:
+			if self.log_address:
+				# Don't bug the user about None not being a valid file, they haven't even given any input yet.
+				print(f"{self.log_address} is not a valid file path.")
+			self.log_address = input("Where's latest.log? > ")
+			log_address_valid = os.path.isfile(self.log_address)
 
 		if self.channels_to_render is None:
 			self.channels_to_render = input("What channels are being rendered? > ")

--- a/Redstone Logic Analyzer Tool/Redstone Logic Analyzer.py
+++ b/Redstone Logic Analyzer Tool/Redstone Logic Analyzer.py
@@ -4,6 +4,8 @@ import os
 
 
 class RedstoneLogicAnalyzer:
+	input_tries_before_exit_prompt = 2
+
 	def __init__(self, log_address=None, channels_to_render=None):
 		self.log_address 		= log_address
 		self.channels_to_render = channels_to_render
@@ -26,12 +28,21 @@ class RedstoneLogicAnalyzer:
 			log_address_valid = os.path.isfile(self.log_address)
 		else:
 			log_address_valid = False
+		
+		multiple_try_message = ""
+		try_count = 0
 
 		while not log_address_valid:
+			try_count += 1
+			if try_count == self.input_tries_before_exit_prompt:
+				multiple_try_message = " (type 'exit' to exit script)"
+
 			if self.log_address:
 				# Don't bug the user about None not being a valid file, they haven't even given any input yet.
 				print(f"{self.log_address} is not a valid file path.")
-			self.log_address = input("Where's latest.log? > ")
+			self.log_address = input(f"Where's latest.log?{multiple_try_message} > ")
+			if self.log_address == "exit":
+				exit("Script aborted at log address input.")
 			log_address_valid = os.path.isfile(self.log_address)
 
 		if self.channels_to_render is None:

--- a/Redstone Logic Analyzer Tool/Redstone Logic Analyzer.py
+++ b/Redstone Logic Analyzer Tool/Redstone Logic Analyzer.py
@@ -1,9 +1,11 @@
 from logic_analyzer.screen_renderer import ScreenRenderer
-	
+from argparse import ArgumentParser
+
+
 class RedstoneLogicAnalyzer:
-	def __init__(self):
-		self.log_address 		= ""
-		self.channels_to_render = None
+	def __init__(self, log_address=None, channels_to_render=None):
+		self.log_address 		= log_address
+		self.channels_to_render = channels_to_render
 		self.renderer			= ScreenRenderer()
 	
 	def main(self):
@@ -12,8 +14,17 @@ class RedstoneLogicAnalyzer:
 		self._report_failed_channels()
 	
 	def _collect_arguments(self):
-		self.log_address 		= input("Where's latest.log? > ")
-		self.channels_to_render = input("What channels are being rendered? > ")
+		"""
+		log_address: str
+		channels_to_render: str
+
+		If log_address or channels_to_render is None then the user will be prompted for it.
+		"""
+		if self.log_address is None:
+			self.log_address 		= input("Where's latest.log? > ")
+
+		if self.channels_to_render is None:
+			self.channels_to_render = input("What channels are being rendered? > ")
 		
 	def _render_and_save_image(self):
 		render = self.renderer.render_log(self.log_address , self.channels_to_render)
@@ -34,9 +45,20 @@ class RedstoneLogicAnalyzer:
 
 if __name__ == "__main__":
 	# execute only if run as a script
+
+	# Get arguments from the command line to make it easier to input the log path and repeat inputs
+	parser = ArgumentParser()
+	parser.add_argument("-l", "--log", type=str, help="Path to latest.log.")
+	parser.add_argument("-c", "--channels", nargs="*", help="The probe names to render. Leave blank to use all channels in default order.")
+
+	args = parser.parse_args()
+	log_address = args.log
+	channels_to_render = args.channels
+	if channels_to_render is not None:
+		channels_to_render = " ".join(channels_to_render)
 	
 	try:
-		RedstoneLogicAnalyzer().main()
+		RedstoneLogicAnalyzer(log_address, channels_to_render).main()
 	except Exception as e:
 		print("Encountered Exception: {}".format(e))
 	input("Press Enter to Continue...")

--- a/Redstone Logic Analyzer Tool/Redstone Logic Analyzer.py
+++ b/Redstone Logic Analyzer Tool/Redstone Logic Analyzer.py
@@ -1,12 +1,14 @@
 from logic_analyzer.screen_renderer import ScreenRenderer
 from argparse import ArgumentParser
 import os
+from pathlib import Path
 
 
 class RedstoneLogicAnalyzer:
 	input_tries_before_exit_prompt = 2
 
-	def __init__(self, log_address=None, channels_to_render=None):
+	def __init__(self, image_save_path, log_address=None, channels_to_render=None):
+		self.image_save_path    = image_save_path
 		self.log_address 		= log_address
 		self.channels_to_render = channels_to_render
 		self.renderer			= ScreenRenderer()
@@ -50,8 +52,9 @@ class RedstoneLogicAnalyzer:
 		
 	def _render_and_save_image(self):
 		render = self.renderer.render_log(self.log_address , self.channels_to_render)
-		render.save('.\image.png')
+		render.save(self.image_save_path)
 		print("Generation Complete!")
+		print(f"Image saved as: {image_save_path}")
 		
 	def _report_failed_channels(self):
 		failures = self.renderer.report_failed_signals()
@@ -72,6 +75,7 @@ if __name__ == "__main__":
 	parser = ArgumentParser()
 	parser.add_argument("-l", "--log", type=str, help="Path to latest.log.")
 	parser.add_argument("-c", "--channels", nargs="*", help="The probe names to render. Leave blank to use all channels in default order.")
+	parser.add_argument("-i", "--image_name", type=str, default="image.png", help="Path to location to save image. If name doesn't end in .png then .png will be appended or replace the given extension.")
 
 	args = parser.parse_args()
 	log_address = args.log
@@ -79,8 +83,11 @@ if __name__ == "__main__":
 	if channels_to_render is not None:
 		channels_to_render = " ".join(channels_to_render)
 	
+	# Strip extra . off the right end if there are extras and then make sure the suffix is .png
+	image_save_path = Path(args.image_name.rstrip(".")).with_suffix(".png")
+
 	try:
-		RedstoneLogicAnalyzer(log_address, channels_to_render).main()
+		RedstoneLogicAnalyzer(image_save_path, log_address, channels_to_render).main()
 	except Exception as e:
 		print("Encountered Exception: {}".format(e))
 	input("Press Enter to Continue...")


### PR DESCRIPTION
I added a check to Redstone Logic Analyzer.py to make sure main() is only called if the script is being run directly and not if it is imported in another script.
I added this since the script could one day be imported by another script as the project grows, in which case it shouldn't be run directly, the calling script should determine when to call main().

I also added the ability to pass in command line arguments for the log path, channels, and image name. This makes it easier to type the log path and image name since autocomplete can help, and it makes it easier (and much faster) to run the script again with the same input by either copy pasting the command or hitting the up arrow to find the command in the command prompt history.

I also added a check to see if a file actually exists at the path the user gave for latestlog.txt before trying to use it. If it doesn't, the user is prompted for the path again.

I added the features in the way that I think makes the most sense using the current architecture of the file (given that it is a class definition), but there are other ways they could have been added. Personally I don't think the file should use a class at all, as it adds nothing to the function of the script, and in the case of my additions makes things a little muddy. For example, should arguments be passed in to init or main? If there was no class, there would be no init, so they'd be passed in to main. Simple. And then arguments would be passed in to each function as required instead of sharing self and having to check for default values and whatnot. That discussion should probably be held elsewhere though. For now I left things alone since those changes weren't necessary to add my improvements.