### PR TITLE
Print Structure Generator argument options as a numbered list

### DIFF
--- a/Redstone Structure Generator Tool/Redstone Structure Generator.py
+++ b/Redstone Structure Generator Tool/Redstone Structure Generator.py
@@ -14,7 +14,8 @@ structures = {
 }
 
 argument_handler = ArgumentHandler()
-Structure = structures[argument_handler.handle(Argument("STRUCTURE", "What kind of structure is being built?", ", ".join(structures.keys())))]
+# argument_handler requires the options to be in a list so it can subscript them using []
+Structure = structures[argument_handler.handle(Argument("STRUCTURE", "What kind of structure is being built?", list(structures.keys())))]
 
 try:
 	commands = generate(Structure(), argument_handler)

--- a/Redstone Structure Generator Tool/structure_generator/argument_handler.py
+++ b/Redstone Structure Generator Tool/structure_generator/argument_handler.py
@@ -17,8 +17,10 @@ class ArgumentHandler:
 		
 	def _get_value_from_argument(self, argument):
 		header_format = "{} - {} > ".format(argument.name, argument.help)
-		error_format = "{{}} is not a valid option. Try {}".format(argument.choices)
-		value = self._get_input_and_check_against_valid_options(header_format, argument.choices, error_format)
+		if argument.choices:
+			value = self._get_input_and_check_against_valid_options(header_format, argument.choices)
+		else:
+			value = input(header_format)
 		return value
 		
 	def _scrub_arguments(self, arguments):
@@ -28,9 +30,24 @@ class ArgumentHandler:
 			arguments = [arguments]
 		return arguments
 			
-	def _get_input_and_check_against_valid_options(self, header, valid_inputs, error_message_format):
-		while True:
-			user_input = input(header)
-			if valid_inputs == None or user_input in valid_inputs:
-				return user_input
-			print(error_message_format.format(user_input))
+	def _get_input_and_check_against_valid_options(self, header, options):
+		num_options = len(options)
+		selected = None
+		print(header)
+		for i, option in enumerate(options):
+			print(f"\t{i+1}: {option}")
+
+		while not selected:
+			user_input = input(f"Type out an option or give its index (1-{num_options}): ")
+			
+			try:
+				option_index = int(user_input)
+				if option_index > 0 and option_index <= num_options:
+					selected = options[option_index-1]
+				else:
+					print(f"{option_index} is not a valid option.")
+			except ValueError:
+				if user_input in options:
+					selected = user_input
+
+		return selected

--- a/Redstone Structure Generator Tool/structure_generator/argument_handler.py
+++ b/Redstone Structure Generator Tool/structure_generator/argument_handler.py
@@ -47,7 +47,15 @@ class ArgumentHandler:
 				else:
 					print(f"{option_index} is not a valid option.")
 			except ValueError:
-				if user_input in options:
-					selected = user_input
+				# Check if any of the options starts with the user input. (Also works if the whole option is typed out.)
+				# To match any option that contains the input instead change 'o.startswith(user_input)' to 'user_input in o'
+				matching_options = [o for o in options if user_input in o] # List comprehension gives us a nice one liner.
+				
+				if len(matching_options) == 0:
+					print("No options matched.")
+				elif len(matching_options) == 1:
+					selected = matching_options[0]
+				else:
+					print("Multiple options matched. Type out enough to match just one.")
 
 		return selected

--- a/Redstone Structure Generator Tool/structure_generator/argument_handler.py
+++ b/Redstone Structure Generator Tool/structure_generator/argument_handler.py
@@ -58,4 +58,5 @@ class ArgumentHandler:
 				else:
 					print("Multiple options matched. Type out enough to match just one.")
 
+		print(f"Selected: {selected}")
 		return selected


### PR DESCRIPTION
The user can type out the option or the number of the argument from the printed list.
They can even type just the start of an option to select it, down to a single letter if there is only one option that starts with that letter.
The selected option is then printed so the user to visually confirm the right option was selected.

Free form arguments with no options (e.g. FILE) still work the same. They get the user's input and that is it.

i.e.:
STRUCTURE - What kind of structure is being built? > 
	1: basic_encoder
	2: stenodyon_decoder
	3: properinglish19_decoder
Type out an option or give its index (1-3): 

Typing basic_encoder, 1, bas, or b will all select basic_encoder.