### PR TITLE
Structure Generator command line arguments

### DIFF
--- a/Redstone Structure Generator Tool/Redstone Structure Generator.py
+++ b/Redstone Structure Generator Tool/Redstone Structure Generator.py
@@ -14,16 +14,21 @@ structures = {
 }
 
 argument_handler = ArgumentHandler()
-Structure = structures[argument_handler.handle(Argument("STRUCTURE", "What kind of structure is being built?", ", ".join(structures.keys())))]
 
-try:
-	commands = generate(Structure(), argument_handler)
-	command_output = AutoTyper()
-	for count, command in enumerate(commands):
-		print("Entering command {} of {}:{}".format(count+1, len(commands), command))
-		command_output.handle(command)
-	command_output.close()
-except Exception as e:
-	print("Encountered Exception: {}".format(e))
-	
-input("Press Enter to Continue...")
+def main(): 
+	Structure = structures[argument_handler.handle(Argument("STRUCTURE", "What kind of structure is being built?", ", ".join(structures.keys())))]
+
+	try:
+		commands = generate(Structure(), argument_handler)
+		command_output = AutoTyper()
+		for count, command in enumerate(commands):
+			print("Entering command {} of {}:{}".format(count+1, len(commands), command))
+			command_output.handle(command)
+		command_output.close()
+	except Exception as e:
+		print("Encountered Exception: {}".format(e))
+		
+	input("Press Enter to Continue...")
+
+if __name__ == "__main__":
+	main()

--- a/Redstone Structure Generator Tool/Redstone Structure Generator.py
+++ b/Redstone Structure Generator Tool/Redstone Structure Generator.py
@@ -5,6 +5,7 @@ from structures.basic_encoder.encoder import Encoder as BasicEncoder
 from structures.properinglish19_decoder.decoder import Decoder as ProperinglishDecoder
 from structures.stenodyon_decoder.decoder import Decoder as StenodyonDecoder
 from string_handlers.autotyper import AutoTyper
+from argparse import ArgumentParser
 import traceback
 
 structures = {
@@ -15,8 +16,16 @@ structures = {
 
 argument_handler = ArgumentHandler()
 
-def main(): 
-	Structure = structures[argument_handler.handle(Argument("STRUCTURE", "What kind of structure is being built?", ", ".join(structures.keys())))]
+def main(structure=None):
+	if structure in structures.keys():
+		Structure = structures[structure]
+	elif structure in structures.values():
+		Structure = structure
+	else:
+		if structure:
+			# If we got here and structure is set then the user gave bad input
+			print(f"'{structure}' isn't a valid structure name.")
+		Structure = structures[argument_handler.handle(Argument("STRUCTURE", "What kind of structure is being built?", ", ".join(structures.keys())))]
 
 	try:
 		commands = generate(Structure(), argument_handler)
@@ -31,4 +40,12 @@ def main():
 	input("Press Enter to Continue...")
 
 if __name__ == "__main__":
-	main()
+	parser = ArgumentParser()
+	structure_arg_group = parser.add_mutually_exclusive_group()
+	structure_arg_group.add_argument("-s", "--structure", help="The name of the structure to build (must match exactly).")
+	structure_arg_group.add_argument("-e", "--basic_encoder", action="store_const", const="basic_encoder", dest="structure", help="Build the basic_encoder.")
+	structure_arg_group.add_argument("-d", "--stenodyon_decoder", action="store_const", const="stenodyon_decoder", dest="structure", help="Build the stenodyon_decoder.")
+	structure_arg_group.add_argument("-p", "--properinglish19_decoder", action="store_const", const="properinglish19_decoder", dest="structure", help="Build the properinglish19_decoder.")
+
+	args = parser.parse_args()
+	main(args.structure)


### PR DESCRIPTION
Added check to see if Redstone Structure Generator is being run as a script (is main) or being called by another script and moved code to a function called main() to make it possible to call.

Added arguments for selecting which structure to build, making it easier to select the structure they want to build and repeat structures using command history.

The user can:
- use -s and type in the name of the structure
- use -s and type in the name of the Python class for the structure
- use one of the other flags to select a structure directly